### PR TITLE
Wrap onStartup users update in try/catch...

### DIFF
--- a/status.coffee
+++ b/status.coffee
@@ -99,17 +99,23 @@ statusEvents.on "connectionActive", (advice) ->
 
 # Reset online status on startup (users will reconnect)
 onStartup = (selector = {}) ->
-  Meteor.users.update selector,
-    {
-      $set: {
-        "status.online": false
+  updateCount = 0
+  try
+    updateCount = Meteor.users.update selector,
+      {
+        $set: {
+          "status.online": false
+        },
+        $unset: {
+          "status.idle": null
+          "status.lastActivity": null
+        }
       },
-      $unset: {
-        "status.idle": null
-        "status.lastActivity": null
-      }
-    },
-    { multi: true }
+      { multi: true }
+  catch e
+    console.log 'UserStatus.onStartup() error setting user status: ', e
+  updateCount
+  
 
 ###
   Local session modifification functions - also used in testing


### PR DESCRIPTION
...in case status property does not yet exist for a given user.

Resolves [issue 91](https://github.com/mizzao/meteor-user-status/issues/91)
