### PR TITLE
fix typo in the schema documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ const userSchema = new SimpleSchema({
         type: String,
         optional: true,
     },
-    'status.iddle': {
+    'status.idle': {
         type: Boolean,
         optional: true,
     },


### PR DESCRIPTION
A typo was left in the last PR I made, see https://github.com/Meteor-Community-Packages/meteor-user-status/pull/127
