### PR TITLE
Added optional startupQuerySelector

### DIFF
--- a/server/status.js
+++ b/server/status.js
@@ -135,7 +135,7 @@ statusEvents.on('connectionActive', (advice) => {
 // Reset online status on startup (users will reconnect)
 const onStartup = (selector) => {
   if (selector == null) {
-    selector = {};
+    selector = { "status.online": true }; // prevent updating ALL users unnecessarily 
   }
   return Meteor.users.update(selector, {
     $set: {

--- a/server/status.js
+++ b/server/status.js
@@ -15,7 +15,7 @@ const UserConnections = new Mongo.Collection('user_status_sessions', {
   connection: null
 });
 
-const statusEvents = new(EventEmitter)();
+const statusEvents = new (EventEmitter)();
 
 /*
   Multiplex login/logout events to status.online
@@ -135,7 +135,7 @@ statusEvents.on('connectionActive', (advice) => {
 // Reset online status on startup (users will reconnect)
 const onStartup = (selector) => {
   if (selector == null) {
-    selector = { $or: [{ "status.online": true }, { "status.idle": { $exists: true } }, { "status.lastActivity": { $exists: true } }] }; // prevent updating ALL users unnecessarily 
+    selector = Meteor?.settings?.packages?.['mizzao:user-status']?.startupQuerySelector || {};
   }
   return Meteor.users.update(selector, {
     $set: {
@@ -184,11 +184,11 @@ const loginSession = (connection, date, userId) => {
 const tryLogoutSession = (connection, date) => {
   let conn;
   if ((conn = UserConnections.findOne({
-      _id: connection.id,
-      userId: {
-        $exists: true
-      }
-    })) == null) {
+    _id: connection.id,
+    userId: {
+      $exists: true
+    }
+  })) == null) {
     return false;
   }
 

--- a/server/status.js
+++ b/server/status.js
@@ -135,7 +135,7 @@ statusEvents.on('connectionActive', (advice) => {
 // Reset online status on startup (users will reconnect)
 const onStartup = (selector) => {
   if (selector == null) {
-    selector = { "status.online": true }; // prevent updating ALL users unnecessarily 
+    selector = { $or: [{ "status.online": true }, { "status.idle": { $exists: true } }, { "status.lastActivity": { $exists: true } }] }; // prevent updating ALL users unnecessarily 
   }
   return Meteor.users.update(selector, {
     $set: {


### PR DESCRIPTION
added optional meteor package setting "startupQuerySelector" to enable custom selection of which users will have their status fields reset... FYI i was checking out the github.dev editor and it did some formatting on `18` and `187-191`